### PR TITLE
feat: make the ElevenLabs TTS model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,36 @@ Each named speaker must be defined in the `config.yaml` file. The default speake
 
 The speed of the audio can be adjusted in the config file. The default is 1.0, but you can set it to any value between 0.7 and 1.3. The speed is per speaker.
 
+## TTS model
+
+By default, `srt11` generates speech with the [`eleven_multilingual_v2`](https://elevenlabs.io/docs/models) ElevenLabs model. You can choose a different model with the optional `tts_model` field, either globally or per speaker:
+
+```yaml
+auth_key: "sk_your_auth_key"
+# Applies to every speaker unless overridden below
+tts_model: "eleven_multilingual_v2"
+default:
+    model: "model_id"
+    name: "Speaker name"
+    speed: 1.1
+models:
+    Joe:
+        model: "joe_model_id"
+        name: "Joe"
+        # Overrides the top-level tts_model just for Joe
+        tts_model: "eleven_flash_v2_5"
+```
+
+The model is resolved per line in this order: the speaker's own `tts_model`, then the top-level `tts_model`, then the built-in default (`eleven_multilingual_v2`). Omitting the field entirely keeps the previous behaviour, so existing configs are unaffected.
+
+> [!NOTE]
+> `tts_model` is the ElevenLabs **model** (the synthesis engine). The `model` field under each speaker is the ElevenLabs **voice ID** and is unrelated.
+
+> [!WARNING]
+> `srt11` relies on the per-speaker `speed` setting and on [request stitching](https://elevenlabs.io/docs/eleven-api/guides/how-to/text-to-speech/request-stitching) for timing and cross-line continuity. Neither is supported by `eleven_v3`, so that model is not recommended here. `eleven_multilingual_v2` and the `eleven_flash_v2_5` / `eleven_flash_v2` models support both and are safe choices.
+
+The selected model is included in the generated file's cache key, so switching models re-generates audio instead of reusing files produced by a different model. The run log also prints the model used for each line, e.g. `Speaking (as Joe via eleven_flash_v2_5)`.
+
 ## Merge lines
 
 If you have multiple lines in a row spoken by the same speaker, you can merge them into line.

--- a/commands/srt11.go
+++ b/commands/srt11.go
@@ -23,26 +23,43 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type SpeakerConfig struct {
+	Model    string  `yaml:"model"` // ElevenLabs voice ID
+	Name     string  `yaml:"name"`
+	Speed    float32 `yaml:"speed"`
+	TTSModel string  `yaml:"tts_model"` // optional: ElevenLabs model ID override for this speaker
+}
+
 type Config struct {
-	AuthKey string `yaml:"auth_key"`
-	Default struct {
-		Model string  `yaml:"model"`
-		Name  string  `yaml:"name"`
-		Speed float32 `yaml:"speed"`
-	} `yaml:"default"`
-	Models map[string]struct {
-		Model string  `yaml:"model"`
-		Name  string  `yaml:"name"`
-		Speed float32 `yaml:"speed"`
-	} `yaml:"models"`
-	MergeLinesThresholdMs int `yaml:"merge_lines_threshold_ms"` // optional
+	AuthKey               string                   `yaml:"auth_key"`
+	TTSModel              string                   `yaml:"tts_model"` // optional: default ElevenLabs model ID for all speakers
+	Default               SpeakerConfig            `yaml:"default"`
+	Models                map[string]SpeakerConfig `yaml:"models"`
+	MergeLinesThresholdMs int                      `yaml:"merge_lines_threshold_ms"` // optional
+}
+
+// defaultTTSModel is used when no tts_model is set anywhere in the config.
+// Kept as the historical default so existing configs behave identically.
+const defaultTTSModel = "eleven_multilingual_v2"
+
+// resolveTTSModel picks the ElevenLabs model ID for a speaker, in order of
+// precedence: per-speaker tts_model, top-level tts_model, built-in default.
+func resolveTTSModel(speaker SpeakerConfig, cfg *Config) string {
+	if speaker.TTSModel != "" {
+		return speaker.TTSModel
+	}
+	if cfg.TTSModel != "" {
+		return cfg.TTSModel
+	}
+	return defaultTTSModel
 }
 
 type Model struct {
-	model  string
-	name   string
-	offset int
-	speed  float32
+	model    string
+	name     string
+	offset   int
+	speed    float32
+	ttsModel string
 }
 
 type Path struct {
@@ -232,7 +249,7 @@ func generatePathTemplate(root string, item *astisub.Item, model Model) Path {
 		dialog = dialog[:50]
 	}
 
-	checksum := md5.Sum([]byte(model.model + fmt.Sprintf("%f", model.speed) + item.String()))
+	checksum := md5.Sum([]byte(model.model + model.ttsModel + fmt.Sprintf("%f", model.speed) + item.String()))
 	template := filepath.Join(root, fmt.Sprintf("%X-%s-%s.%%s.mp3", checksum[:4], model.name, dialog))
 
 	glob := fmt.Sprintf(template, "*")
@@ -365,9 +382,9 @@ func parseSubtitleFile(config *Config, path string, mergeLinesThresholdMs int) [
 		var model Model
 		if modelName != "" {
 			modelConfig := config.Models[modelName]
-			model = Model{name: modelConfig.Name, model: modelConfig.Model, offset: modelChannels[modelName], speed: modelConfig.Speed}
+			model = Model{name: modelConfig.Name, model: modelConfig.Model, offset: modelChannels[modelName], speed: modelConfig.Speed, ttsModel: resolveTTSModel(modelConfig, config)}
 		} else {
-			model = Model{name: config.Default.Name, model: config.Default.Model, offset: 0, speed: config.Default.Speed}
+			model = Model{name: config.Default.Name, model: config.Default.Model, offset: 0, speed: config.Default.Speed, ttsModel: resolveTTSModel(config.Default, config)}
 		}
 
 		item := Item{
@@ -422,14 +439,14 @@ func generateMissingVoiceLines(client *elevenlabs.Client, items []Item) []AudioF
 			nextRequestIds = append(nextRequestIds, items[i].Path.Id)
 		}
 
-		log.Printf("Speaking (as %s) \"%s\"\n", item.Model.name, item.Sub.String())
+		log.Printf("Speaking (as %s via %s) \"%s\"\n", item.Model.name, item.Model.ttsModel, item.Sub.String())
 		ttsReq := elevenlabs.TextToSpeechRequest{
 			VoiceSettings: &elevenlabs.VoiceSettings{
 				SpeakerBoost: true,
 				Speed:        item.Model.speed,
 			},
 			Text:               item.Sub.String(),
-			ModelID:            "eleven_multilingual_v2",
+			ModelID:            item.Model.ttsModel,
 			PreviousRequestIds: previousRequestIds,
 			NextRequestIds:     nextRequestIds,
 			NextText:           nextText,

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -1,4 +1,8 @@
 auth_key: "sk_your_auth_key"
+# Optional: ElevenLabs TTS model ID used for all speakers.
+# Defaults to "eleven_multilingual_v2" if omitted.
+# See https://github.com/dkarlovi/srt11?tab=readme-ov-file#tts-model
+tts_model: "eleven_multilingual_v2"
 default:
     model: "model_id"
     name: "Speaker name"
@@ -11,4 +15,5 @@ models:
     Joe:
         model: "joe_model_id"
         name: "Joe"
-
+        # Optional: per-speaker TTS model override (falls back to top-level tts_model)
+        # tts_model: "eleven_flash_v2_5"


### PR DESCRIPTION
# feat: make the ElevenLabs TTS model configurable

## Summary

Adds an optional `tts_model` config field so the ElevenLabs synthesis model can be
chosen from `config.yaml`, instead of being hard-coded to `eleven_multilingual_v2`.
The model can be set globally and/or overridden per speaker. Behaviour is unchanged
for existing configs.

## Motivation

The TTS model was previously hard-coded:

```go
ModelID: "eleven_multilingual_v2",
```

This meant users could not opt into other ElevenLabs models — for example
`eleven_flash_v2_5` for lower cost/latency on bulk runs. Exposing the model as a
config option is a small, backward-compatible change.

Note this is distinct from the existing per-speaker `model` field, which is the
ElevenLabs **voice ID**, not the synthesis model. The new field is named `tts_model`
to keep that distinction explicit and avoid a breaking rename.

## What changed

- **`commands/srt11.go`**
  - Extracted the duplicated inline speaker struct into a named `SpeakerConfig`
    type (used by both `Default` and `Models`).
  - Added `TTSModel` to `SpeakerConfig` (per-speaker override) and a top-level
    `TTSModel` to `Config` (global default).
  - Added `resolveTTSModel()`, which resolves the model per line with precedence:
    per-speaker `tts_model` → top-level `tts_model` → built-in default
    (`eleven_multilingual_v2`).
  - Added a `ttsModel` field to the internal `Model` struct and passed the
    resolved value to the TTS request instead of the literal.
  - Included the model in the generated file's cache checksum, so switching
    models regenerates audio rather than reusing files made with a different model.
  - The per-line log now reports the model used, e.g.
    `Speaking (as Joe via eleven_flash_v2_5)`.
- **`config.yaml.dist`** — documents the new `tts_model` field (global + per-speaker).
- **`README.md`** — adds a "TTS model" section covering precedence, the
  voice-ID-vs-model distinction, caching behaviour, and a compatibility note.

## Backward compatibility

`tts_model` is optional at every level. Configs that don't set it resolve to
`eleven_multilingual_v2`, exactly as before. The config decoder still runs with
`KnownFields(true)`; the new field is additive, so old configs continue to parse.

## Compatibility note (in README + config)

`srt11` depends on the per-speaker `speed` setting and on ElevenLabs request
stitching (`previous_request_ids` / `next_request_ids` / `next_text`) for timing
and cross-line continuity. Neither is supported by `eleven_v3`, so that model is
called out as not recommended. `eleven_multilingual_v2` and the
`eleven_flash_v2_5` / `eleven_flash_v2` models support both.

## Example

```yaml
auth_key: "sk_..."
tts_model: "eleven_multilingual_v2"   # global default
default:
    model: "voice_id"                 # voice ID (unchanged semantics)
    name: "Speaker name"
    speed: 1.1
models:
    Joe:
        model: "joe_voice_id"
        name: "Joe"
        tts_model: "eleven_flash_v2_5" # per-speaker override
```

## Testing

- `gofmt` clean; change is additive and adds no new dependencies.
- Static analysis of the wiring: no remaining hard-coded model literal; `ttsModel`
  is threaded through construction, cache key, request, and log consistently.
- Suggested manual validation (per the repo's contributor guide), which requires a
  local Go 1.23+ toolchain:

  ```bash
  go build -o srt11 .
  go vet ./...
  go fmt ./... && git diff --exit-code

  # Smoke test: parsing should succeed and only fail at the API call.
  # With no tts_model set, the log should read "... via eleven_multilingual_v2".
  ./srt11 -c dummy_config.yaml test.srt
  ```
